### PR TITLE
Fix `strpos(): Empty needle` warning

### DIFF
--- a/sem-external-links.php
+++ b/sem-external-links.php
@@ -724,7 +724,9 @@ class sem_external_links {
 	    $subdomains = $domain;
 	    $domain = $this->extract_domain($subdomains);
 
-		$subdomains = rtrim( substr($subdomains, 0, strpos($subdomains, $domain)) );
+	    if(!empty($domain)){
+	        $subdomains = rtrim( substr($subdomains, 0, strpos($subdomains, $domain)) );
+	    }
 
 	    return $subdomains;
 	} # extract_subdomains()


### PR DESCRIPTION
Fix https://wordpress.org/support/topic/strpos-error-1.
