### PR TITLE
Update sem-external-links.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "semiologic/sem-external-links",
+  "description": "External Links",
+  "type": "wordpress-plugin",
+  "require": {}
+}

--- a/sem-external-links.php
+++ b/sem-external-links.php
@@ -449,7 +449,7 @@ class sem_external_links {
 		$attr_value     = false;
 		$quote          = false; // quotes to wrap attribute values
 
-		preg_match('/(<a.*>)/iU', $html, $match);
+		preg_match('/(<a.*>)/isU', $html, $match);
 
 		$link_str = $match[1];
 		if ($link_str == "")


### PR DESCRIPTION
Fixed bug where link with line breaks would get around the filter, and (at least on our systems) potentially eat a bunch of comments and break HTML.

See #2.